### PR TITLE
Implement Hit Target with LineTrace

### DIFF
--- a/Source/Blaster/Public/BlasterComponents/CombatComponent.h
+++ b/Source/Blaster/Public/BlasterComponents/CombatComponent.h
@@ -4,6 +4,8 @@
 #include "GameFramework/Actor.h"
 #include "CombatComponent.generated.h"
 
+const float TRACE_LENGTH = 80000.f;
+
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class BLASTER_API UCombatComponent : public UActorComponent
 {
@@ -35,6 +37,8 @@ protected:
 	UFUNCTION(NetMulticast, Reliable)
 	void MulticastFire();
 	
+	void TraceUnderCrosshairs(FHitResult& TraceHitResult);
+	
 private:
 	class ABlasterCharacter* Character;
 
@@ -51,4 +55,5 @@ private:
 	float AimWalkSpeed;
 	
 	bool bFireButtonPressed;
+	
 };


### PR DESCRIPTION
- [x] #55 

##### 구현 사항
- `CombatComponent`
  - 화면 중앙 포지션(카메라)에서 수직 벡터의 월드 포지션, 월드 방향 벡터 추출
  - 포지션 및 방향을 기준으로 라인트레이싱 실시
  - 라인트레이싱에 부딪히는 포지션 확인