### PR TITLE
Implement Projectiole Tracer

### DIFF
--- a/Source/Blaster/Private/Weapon/Projectile.cpp
+++ b/Source/Blaster/Private/Weapon/Projectile.cpp
@@ -5,10 +5,15 @@
 
 #include "Components/BoxComponent.h"
 #include "GameFramework/ProjectileMovementComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "Particles/ParticleSystem.h"
+#include "Particles/ParticleSystemComponent.h"
 
 AProjectile::AProjectile()
 {
 	PrimaryActorTick.bCanEverTick = true;
+	bReplicates = true; // 복제 수행
+	
 	CollisionBox = CreateDefaultSubobject<UBoxComponent>(TEXT("CollisionBox"));
 	SetRootComponent(CollisionBox);
 	CollisionBox->SetCollisionObjectType(ECollisionChannel::ECC_WorldDynamic);
@@ -24,6 +29,18 @@ AProjectile::AProjectile()
 void AProjectile::BeginPlay()
 {
 	Super::BeginPlay();
+
+	if (Tracer)
+	{
+		TracerComponent = UGameplayStatics::SpawnEmitterAttached(
+			Tracer,
+			CollisionBox,
+			FName(),
+			GetActorLocation(),
+			GetActorRotation(),
+			EAttachLocation::KeepWorldPosition
+		);
+	}
 	
 }
 

--- a/Source/Blaster/Private/Weapon/ProjectileWeapon.cpp
+++ b/Source/Blaster/Private/Weapon/ProjectileWeapon.cpp
@@ -8,6 +8,9 @@
 void AProjectileWeapon::Fire(const FVector& HitTarget)
 {
 	Super::Fire(HitTarget);
+	
+	if (!HasAuthority()) return;
+	
 	APawn* InstigatorPawn = Cast<APawn>(GetOwner());
 	const USkeletalMeshSocket* MuzzleFlashSocket = GetWeaponMesh()->GetSocketByName(FName("MuzzleFlash"));
 	if (MuzzleFlashSocket)

--- a/Source/Blaster/Public/Weapon/Projectile.h
+++ b/Source/Blaster/Public/Weapon/Projectile.h
@@ -25,4 +25,8 @@ private:
 	UPROPERTY(VisibleAnywhere)
 	class UProjectileMovementComponent* ProjectileMovementComponent;
 
+	UPROPERTY(EditAnywhere)
+	class UParticleSystem* Tracer;
+
+	class UParticleSystemComponent* TracerComponent;
 };


### PR DESCRIPTION
- [x] #58 

##### 구현사항
- 투사체 이동방향으로 이펙트 추가
```c++
	if (Tracer)
	{
		TracerComponent = UGameplayStatics::SpawnEmitterAttached(
			Tracer,
			CollisionBox,
			FName(),
			GetActorLocation(),
			GetActorRotation(),
			EAttachLocation::KeepWorldPosition
		);
	}
```
- 투사체 생성 이벤트를 서버에서만 실행
- HasAuthority() - 서버에 권한이 있음. 즉, 클라이언트가 독립적으로 보유하지 않음
```c++
	Super::Fire(HitTarget);
	
	if (!HasAuthority()) return;
```
- 서버에서 생성한 투사체 클라이언트에게 복제(Replicated)
```c++
AProjectile::AProjectile()
{
	PrimaryActorTick.bCanEverTick = true;
	bReplicates = true; // 복제 수행
```