### PR TITLE
Implement Replicating the Hit Target

### DIFF
--- a/Source/Blaster/Private/BlasterComponents/CombatComponent.cpp
+++ b/Source/Blaster/Private/BlasterComponents/CombatComponent.cpp
@@ -71,8 +71,10 @@ void UCombatComponent::FireButtonPressed(bool bPressed)
 {
 	bFireButtonPressed = bPressed;
 	if (bFireButtonPressed)
-	{
-		ServerFire();
+	{	
+		FHitResult HitResult;
+		TraceUnderCrosshairs(HitResult);
+		ServerFire(HitResult.ImpactPoint);
 	}
 }
 
@@ -106,38 +108,22 @@ void UCombatComponent::TraceUnderCrosshairs(FHitResult& TraceHitResult)
 			End,
 			ECollisionChannel::ECC_Visibility
 		);
-		if (!TraceHitResult.bBlockingHit)
-		{
-			TraceHitResult.ImpactPoint = End;
-			HitTarget = End;
-		}
-		else
-		{
-			HitTarget = TraceHitResult.ImpactPoint;
-			DrawDebugSphere(
-				GetWorld(),
-				TraceHitResult.ImpactPoint,
-				12.f,
-				12,
-				FColor::Red
-			);
-		}
 	}
 }
 
-void UCombatComponent::ServerFire_Implementation()
+void UCombatComponent::ServerFire_Implementation(const FVector_NetQuantize& TraceHitTarget)
 {
-	MulticastFire();
+	MulticastFire(TraceHitTarget);
 }
 
 
-void UCombatComponent::MulticastFire_Implementation()
+void UCombatComponent::MulticastFire_Implementation(const FVector_NetQuantize& TraceHitTarget)
 {
 	if (EquippedWeapon == nullptr) return;
 	if (Character)
 	{
 		Character->PlayFireMontage(bAiming);
-		EquippedWeapon->Fire(HitTarget);
+		EquippedWeapon->Fire(TraceHitTarget);
 	}
 }
 
@@ -146,9 +132,6 @@ void UCombatComponent::MulticastFire_Implementation()
 void UCombatComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-
-	FHitResult HitResult;
-	TraceUnderCrosshairs(HitResult);
 }
 
 

--- a/Source/Blaster/Public/BlasterComponents/CombatComponent.h
+++ b/Source/Blaster/Public/BlasterComponents/CombatComponent.h
@@ -32,10 +32,10 @@ protected:
 	void FireButtonPressed(bool bPressed);
 
 	UFUNCTION(Server, Reliable)
-	void ServerFire();
+	void ServerFire(const FVector_NetQuantize& TraceHitTarget);
 
 	UFUNCTION(NetMulticast, Reliable)
-	void MulticastFire();
+	void MulticastFire(const FVector_NetQuantize& TraceHitTarget);
 	
 	void TraceUnderCrosshairs(FHitResult& TraceHitResult);
 	
@@ -55,7 +55,4 @@ private:
 	float AimWalkSpeed;
 	
 	bool bFireButtonPressed;
-
-	FVector HitTarget;
-	
 };


### PR DESCRIPTION
- [x] #59 

##### 구현사항
- FVector_NetQuantize 구조체로 서버에 Hit Target 전달 및 복제
  -  FVector_NetQuantize : 벡터 전달 시 실수값을 정수로 변환하여 4byte = 32bit * 3 = 96bit 전달을 20bit * 3 = 60bit로 최적화하여 전달한다.
```C++
	UFUNCTION(Server, Reliable)
	void ServerFire(const FVector_NetQuantize& TraceHitTarget);

	UFUNCTION(NetMulticast, Reliable)
	void MulticastFire(const FVector_NetQuantize& TraceHitTarget);
```